### PR TITLE
Fix assignment into empty filter lens

### DIFF
--- a/R/base-lenses.R
+++ b/R/base-lenses.R
@@ -363,7 +363,9 @@ env_l <- lens(environment, `environment<-`)
 rows_l <- function(rows, drop = FALSE){
   lens(view = function(d) d[rows, ,drop = drop]
      , set = function(d, x){
-       d[rows, ] <- x
+       if (length(rows) > 0){
+         d[rows, ] <- x
+       }
        d
      })
 }

--- a/R/dataframe-lenses.R
+++ b/R/dataframe-lenses.R
@@ -30,7 +30,9 @@ filter_il <- function(...){
        }
      , set = function(d,x){
          filt_vec <- rlang::eval_tidy(filt_quo, d)
-         d[filt_vec,] <- x
+         if (any(filt_vec)){
+           d[filt_vec,] <- x
+         }
          d
      })
 }
@@ -67,7 +69,9 @@ filter_l <- function(...){
        }
      , set = function(d,x){
          filt_vec <- rlang::eval_tidy(filt_expr, d)
-         d[filt_vec, ! names(d) %in% expr_symbols] <- x
+         if (any(filt_vec)) {
+           d[filt_vec, ! names(d) %in% expr_symbols] <- x
+         }
          d
      })
 }


### PR DESCRIPTION
Assigning into an empty filter doesn't work when composed with an `index_l` afterwards. This seems to have to do with special semantics in data.frame indexing, e.g.,

```
d[i,"c"] <- y
```

works when `i` is empty, but 

```
d[i,][,"c"] <- y
```

does not. I've added a simple check to ensure that the filter is not empty before performing the assignment.